### PR TITLE
🧹 Remove naked return in findthem

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,8 @@ func countthem(a []bool) (t int, f int) {
 	return
 }
 
-func findthem(a []bool) (t []int, f []int) {
+func findthem(a []bool) ([]int, []int) {
+	var t, f []int
 	for i, e := range a {
 		if e {
 			t = append(t, i)

--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ func findthem(a []bool) (t []int, f []int) {
 			f = append(f, i)
 		}
 	}
-	return
+	return t, f
 }
 
 func isADigit(a []bool) ([]byte, bool) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"reflect"
 	"testing"
 )
 
@@ -254,5 +255,50 @@ func TestIsADigit(t *testing.T) {
 			log.Printf("Failed on #%d (expected %s) got (%s %v)", i, each.b, b, ok)
 			t.Fail()
 		}
+	}
+}
+
+func TestFindThem(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []bool
+		wantTrue  []int
+		wantFalse []int
+	}{
+		{
+			name:      "mixed",
+			input:     []bool{true, false, true, false, true},
+			wantTrue:  []int{0, 2, 4},
+			wantFalse: []int{1, 3},
+		},
+		{
+			name:      "all true",
+			input:     []bool{true, true, true},
+			wantTrue:  []int{0, 1, 2},
+			wantFalse: nil,
+		},
+		{
+			name:      "all false",
+			input:     []bool{false, false},
+			wantTrue:  nil,
+			wantFalse: []int{0, 1},
+		},
+		{
+			name:      "empty",
+			input:     []bool{},
+			wantTrue:  nil,
+			wantFalse: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTrue, gotFalse := findthem(tt.input)
+			if !reflect.DeepEqual(gotTrue, tt.wantTrue) {
+				t.Errorf("findthem() gotTrue = %v, want %v", gotTrue, tt.wantTrue)
+			}
+			if !reflect.DeepEqual(gotFalse, tt.wantFalse) {
+				t.Errorf("findthem() gotFalse = %v, want %v", gotFalse, tt.wantFalse)
+			}
+		})
 	}
 }


### PR DESCRIPTION
* 🎯 **What:** ADDRESSED naked return in `findthem` in `main.go`.
* 💡 **Why:** Explicit returns improve code readability and maintainability by making data flow clear.
* ✅ **Verification:** Added `TestFindThem` to `main_test.go` covering various input scenarios. Verified that tests pass before and after the refactor.
* ✨ **Result:** The `findthem` function now uses explicit return values.

---
*PR created automatically by Jules for task [6622541744392073405](https://jules.google.com/task/6622541744392073405) started by @arran4*