### PR TITLE
🧹 Refactor countthem to use explicit return

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func countthem(a []bool) (t int, f int) {
 			f++
 		}
 	}
-	return
+	return t, f
 }
 
 func findthem(a []bool) (t []int, f []int) {

--- a/main_test.go
+++ b/main_test.go
@@ -256,3 +256,25 @@ func TestIsADigit(t *testing.T) {
 		}
 	}
 }
+
+func TestCountThem(t *testing.T) {
+	expected := []struct {
+		t     int
+		f     int
+		input []bool
+	}{
+		{0, 0, []bool{}},
+		{1, 0, []bool{true}},
+		{0, 1, []bool{false}},
+		{1, 1, []bool{true, false}},
+		{2, 1, []bool{true, false, true}},
+		{3, 0, []bool{true, true, true}},
+		{0, 3, []bool{false, false, false}},
+	}
+	for i, each := range expected {
+		if tr, fr := countthem(each.input); tr != each.t || fr != each.f {
+			log.Printf("Failed on #%d (expected %d, %d) got (%d, %d)", i, each.t, each.f, tr, fr)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Refactored the countthem function in main.go to use explicit return values instead of naked returns. This improves code clarity and maintainability. Also added a unit test TestCountThem in main_test.go to verify the function's behavior.

---
*PR created automatically by Jules for task [18398731531058808317](https://jules.google.com/task/18398731531058808317) started by @arran4*