### PR TITLE
Fix panic in isANumber with invalid slice length

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,6 +151,9 @@ func isADigit(a []bool) ([]byte, bool) {
 }
 
 func isANumber(a []bool) (int, bool) {
+	if len(a)%7 != 0 {
+		return 0, false
+	}
 	str := []byte{}
 	for i := 0; i < len(a); i += 7 {
 		if b, ok := isADigit(a[i : i+7]); !ok {

--- a/main_test.go
+++ b/main_test.go
@@ -128,6 +128,14 @@ func TestIsANumber(t *testing.T) {
 			true, true,
 			false,
 		}},
+		{0, false, []bool{
+			false,
+			false, false,
+			false,
+			false, false,
+			false,
+			false,
+		}},
 	}
 	for i, each := range expected {
 		if b, ok := isANumber(each.input); b != each.b || ok != each.ok {


### PR DESCRIPTION
Addressed a potential panic in `isANumber` by validating input length.
- Added check: `len(a) % 7 != 0` returns `0, false`.
- Added test case: Slice of length 8 in `TestIsANumber` to verify the fix and prevent regression.


---
*PR created automatically by Jules for task [14732313643970733887](https://jules.google.com/task/14732313643970733887) started by @arran4*