### PR TITLE
🔒 Security Fix: Arbitrary File Write via Output Filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,6 +200,9 @@ func main() {
 		false, false,
 		false,
 	}
+	if err := validatePath(*outfn); err != nil {
+		log.Panicf("Invalid output path: %v", err)
+	}
 	outf, err := os.Create(*outfn)
 	if err != nil {
 		log.Panicf("%v", err)

--- a/path_validation.go
+++ b/path_validation.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func validatePath(path string) error {
+	cleanPath := filepath.Clean(path)
+	if filepath.IsAbs(cleanPath) {
+		return fmt.Errorf("absolute paths are not allowed")
+	}
+	parts := strings.Split(cleanPath, string(os.PathSeparator))
+	for _, part := range parts {
+		if part == ".." {
+			return fmt.Errorf("directory traversal is not allowed")
+		}
+	}
+	return nil
+}

--- a/path_validation_test.go
+++ b/path_validation_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidatePath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{"Valid relative path", "output.gif", false},
+		{"Valid subdir path", "subdir/output.gif", false},
+		{"Invalid absolute path", "/tmp/output.gif", true},
+		{"Invalid directory traversal", "../output.gif", true},
+		{"Invalid deep traversal", "subdir/../../output.gif", true},
+		{"Invalid parent directory", "..", true},
+		{"Valid explicit relative", "./output.gif", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validatePath(tt.path); (err != nil) != tt.wantErr {
+				t.Errorf("validatePath(%q) error = %v, wantErr %v", tt.path, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** Fixed an arbitrary file write vulnerability where the user-supplied output filename (`-out` flag) could traverse directories or specify absolute paths.
⚠️ **Risk:** An attacker could potentially overwrite critical files on the system or write files outside the intended directory.
🛡️ **Solution:** Implemented `validatePath` function in `path_validation.go` to enforce that output paths are relative and contained within the current working directory (no `..` components or absolute paths). Added comprehensive unit tests in `path_validation_test.go`.

---
*PR created automatically by Jules for task [4890381713841937745](https://jules.google.com/task/4890381713841937745) started by @arran4*