### PR TITLE
Refactor test failure reporting in main_test.go

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"testing"
 )
 
@@ -131,8 +130,7 @@ func TestIsANumber(t *testing.T) {
 	}
 	for i, each := range expected {
 		if b, ok := isANumber(each.input); b != each.b || ok != each.ok {
-			log.Printf("Failed on #%d (expected %d) got (%d %v)", i, each.b, b, ok)
-			t.Fail()
+			t.Errorf("Failed on #%d (expected %d) got (%d %v)", i, each.b, b, ok)
 		}
 	}
 }
@@ -251,8 +249,7 @@ func TestIsADigit(t *testing.T) {
 	}
 	for i, each := range expected {
 		if b, ok := isADigit(each.input); string(b) != each.b || ok != each.ok {
-			log.Printf("Failed on #%d (expected %s) got (%s %v)", i, each.b, b, ok)
-			t.Fail()
+			t.Errorf("Failed on #%d (expected %s) got (%s %v)", i, each.b, b, ok)
 		}
 	}
 }


### PR DESCRIPTION
This change improves code health by replacing the non-idiomatic test failure reporting pattern `log.Printf(...)` followed by `t.Fail()` with `t.Errorf(...)`. This provides a cleaner and more standard way to report test failures in Go.

The changes were applied to:
- `TestIsANumber`
- `TestIsADigit`

Verification:
- Ran `go test` to ensure all tests pass.
- Temporarily introduced a failure to verify that `t.Errorf` correctly reports the error message.

---
*PR created automatically by Jules for task [15999623586469587732](https://jules.google.com/task/15999623586469587732) started by @arran4*