### PR TITLE
🧪 Fix panic in isADigit with short slice

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,6 +117,9 @@ func findthem(a []bool) (t []int, f []int) {
 }
 
 func isADigit(a []bool) ([]byte, bool) {
+	if len(a) < 7 {
+		return []byte{}, false
+	}
 	switch {
 	case a[0] && a[1] && a[2] && a[3] && a[4] && a[5] && a[6]:
 		return []byte("8"), true

--- a/main_test.go
+++ b/main_test.go
@@ -248,6 +248,10 @@ func TestIsADigit(t *testing.T) {
 			true, true,
 			false,
 		}},
+		{"", false, []bool{
+			true,
+			true, true,
+		}},
 	}
 	for i, each := range expected {
 		if b, ok := isADigit(each.input); string(b) != each.b || ok != each.ok {


### PR DESCRIPTION
This PR fixes a potential panic in the `isADigit` function in `main.go`.

🎯 **What:**
The `isADigit` function was accessing indices 0 through 6 of the input slice `a` without checking its length. If `a` had fewer than 7 elements, this would cause a runtime panic.

📊 **Coverage:**
- Added a length check: `if len(a) < 7 { return []byte{}, false }`.
- Added a new test case to `TestIsADigit` in `main_test.go` with a short slice `[]bool{true, true, true}` to verify the fix.

✨ **Result:**
The function now safely handles short slices by returning `false`, and the new test case passes. Existing tests also pass.

---
*PR created automatically by Jules for task [14011544609257413792](https://jules.google.com/task/14011544609257413792) started by @arran4*