### PR TITLE
🔒 Security Fix: Predictable Temporary Filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ var (
 	backgroundColour = color.Black
 	matchColour      = color.RGBA{0xA5, 0x2A, 0x2A, math.MaxUint8}
 	matchHeadColour  = color.RGBA{255, 0, 0, math.MaxUint8}
-	outfn            = flag.String("out", fmt.Sprintf("out-%d.gif", time.Now().Unix()), "output filename")
+	outfn            = flag.String("out", "", "output filename")
 )
 
 func drawMatch(img draw.Image, x, y int, leftRight bool) error {
@@ -200,9 +200,20 @@ func main() {
 		false, false,
 		false,
 	}
-	outf, err := os.Create(*outfn)
-	if err != nil {
-		log.Panicf("%v", err)
+
+	var outf *os.File
+	var err error
+	if *outfn == "" {
+		outf, err = os.CreateTemp(".", "out-*.gif")
+		if err != nil {
+			log.Panicf("%v", err)
+		}
+		*outfn = outf.Name()
+	} else {
+		outf, err = os.Create(*outfn)
+		if err != nil {
+			log.Panicf("%v", err)
+		}
 	}
 
 	fontSize, _ := font.BoundString(inconsolata.Regular8x16, "01234\n56789")

--- a/main.go
+++ b/main.go
@@ -204,6 +204,7 @@ func main() {
 	var outf *os.File
 	var err error
 	if *outfn == "" {
+		// Note: os.CreateTemp creates a persistent file that is not automatically deleted.
 		outf, err = os.CreateTemp(".", "out-*.gif")
 		if err != nil {
 			log.Panicf("%v", err)

--- a/main.go
+++ b/main.go
@@ -34,7 +34,6 @@ var (
 	backgroundColour = color.Black
 	matchColour      = color.RGBA{0xA5, 0x2A, 0x2A, math.MaxUint8}
 	matchHeadColour  = color.RGBA{255, 0, 0, math.MaxUint8}
-	outfn            = flag.String("out", "", "output filename")
 )
 
 func drawMatch(img draw.Image, x, y int, leftRight bool) error {
@@ -168,6 +167,7 @@ func isANumber(a []bool) (int, bool) {
 
 func main() {
 	start := time.Now()
+	outfn := flag.String("out", "", "output filename")
 	flag.Parse()
 	initial := []bool{
 		false,


### PR DESCRIPTION
*   🎯 **What:** Fixed a security vulnerability where the default output filename was predictable (based on the current timestamp).
*   ⚠️ **Risk:** Predictable filenames can lead to symlink attacks or race conditions in multi-user environments, potentially allowing an attacker to overwrite sensitive files or crash the application.
*   🛡️ **Solution:** Changed the default behavior to use `os.CreateTemp` when no output filename is provided. This generates a secure, random filename (e.g., `out-123456.gif`) in the current directory, ensuring uniqueness and preventing predictability. If a filename is provided by the user, the application uses it as before.

---
*PR created automatically by Jules for task [16419832032324370147](https://jules.google.com/task/16419832032324370147) started by @arran4*