### PR TITLE
🔒 Fix unsafe use of log.Panicf in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func main() {
 	}
 	outf, err := os.Create(*outfn)
 	if err != nil {
-		log.Panicf("%v", err)
+		log.Fatalf("%v", err)
 	}
 
 	fontSize, _ := font.BoundString(inconsolata.Regular8x16, "01234\n56789")
@@ -221,7 +221,7 @@ func main() {
 	}
 	err = drawPic(initial, img)
 	if err != nil {
-		log.Panicf("%v", err)
+		log.Fatalf("%v", err)
 	}
 	notfree, free := countthem(initial)
 	permutations := free * notfree * (free - 1) * (notfree - 1)
@@ -300,7 +300,7 @@ func main() {
 		img2 := image.NewPaletted(r, p)
 		err = drawPic(mutate, img2)
 		if err != nil {
-			log.Panicf("%v", err)
+			log.Fatalf("%v", err)
 		}
 		d := &font.Drawer{
 			Face: inconsolata.Regular8x16,
@@ -318,14 +318,14 @@ func main() {
 
 	err = gif.EncodeAll(outf, &g)
 	if err != nil {
-		log.Panicf("%v", err)
+		log.Fatalf("%v", err)
 	}
 
 	log.Printf("Gif generated saving: %s", *outfn)
 
 	err = outf.Close()
 	if err != nil {
-		log.Panicf("%v", err)
+		log.Fatalf("%v", err)
 	}
 
 	log.Printf("Done in %s", time.Now().Sub(start))


### PR DESCRIPTION
🎯 **What:** Replaced `log.Panicf` with `log.Fatalf` in `main.go` for handling runtime errors (file creation, image drawing, GIF encoding, file closing).
⚠️ **Risk:** The use of `log.Panicf` causes the application to crash with a stack trace when encountering runtime errors (e.g., permission denied). This exposes internal implementation details (paths, function names) and provides a poor user experience.
🛡️ **Solution:** `log.Fatalf` logs the error message and exits with status 1, which is the standard behavior for CLI tools encountering fatal errors. This prevents information leakage and ensures a clean exit.

---
*PR created automatically by Jules for task [5634583560433786333](https://jules.google.com/task/5634583560433786333) started by @arran4*