### PR TITLE
Refactor isANumber to use integer arithmetic

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"math"
 	"os"
 	"sort"
-	"strconv"
 	"time"
 )
 
@@ -116,54 +115,60 @@ func findthem(a []bool) (t []int, f []int) {
 	return
 }
 
-func isADigit(a []bool) ([]byte, bool) {
+func isADigit(a []bool) (int, int, bool) {
 	switch {
 	case a[0] && a[1] && a[2] && a[3] && a[4] && a[5] && a[6]:
-		return []byte("8"), true
+		return 8, 1, true
 	case a[0] && a[1] && !a[2] && a[3] && a[4] && a[5] && a[6]:
-		return []byte("6"), true
+		return 6, 1, true
 	case a[0] && a[1] && a[2] && !a[3] && a[4] && a[5] && a[6]:
-		return []byte("0"), true
+		return 0, 1, true
 	case a[0] && a[1] && a[2] && a[3] && !a[4] && a[5] && a[6]:
-		return []byte("9"), true
+		return 9, 1, true
 	case a[0] && a[1] && a[2] && a[3] && !a[4] && a[5] && !a[6]:
-		return []byte("9"), true
+		return 9, 1, true
 	case a[0] && !a[1] && a[2] && !a[3] && !a[4] && a[5] && !a[6]:
-		return []byte("7"), true
+		return 7, 1, true
 	case a[0] && a[1] && !a[2] && a[3] && !a[4] && a[5] && a[6]:
-		return []byte("5"), true
+		return 5, 1, true
 	case !a[0] && a[1] && a[2] && a[3] && !a[4] && a[5] && !a[6]:
-		return []byte("4"), true
+		return 4, 1, true
 	case a[0] && !a[1] && a[2] && a[3] && !a[4] && a[5] && a[6]:
-		return []byte("3"), true
+		return 3, 1, true
 	case a[0] && !a[1] && a[2] && a[3] && a[4] && !a[5] && a[6]:
-		return []byte("2"), true
+		return 2, 1, true
 	case !a[0] && a[1] && !a[2] && !a[3] && a[4] && !a[5] && !a[6]:
-		return []byte("1"), true
+		return 1, 1, true
 	case !a[0] && !a[1] && a[2] && !a[3] && !a[4] && a[5] && !a[6]:
-		return []byte("1"), true
+		return 1, 1, true
 	case !a[0] && a[1] && a[2] && !a[3] && a[4] && a[5] && !a[6]:
-		return []byte("11"), true
+		return 11, 2, true
 	case !a[0] && !a[1] && !a[2] && !a[3] && !a[4] && !a[5] && !a[6]:
-		return []byte(""), true
+		return 0, 0, true
 	}
-	return []byte{}, false
+	return 0, 0, false
 }
 
 func isANumber(a []bool) (int, bool) {
-	str := []byte{}
+	n := 0
+	totalDigits := 0
 	for i := 0; i < len(a); i += 7 {
-		if b, ok := isADigit(a[i : i+7]); !ok {
+		val, digits, ok := isADigit(a[i : i+7])
+		if !ok {
 			return 0, false
-		} else {
-			str = append(str, b...)
+		}
+		if digits > 0 {
+			for k := 0; k < digits; k++ {
+				n *= 10
+			}
+			n += val
+			totalDigits += digits
 		}
 	}
-	if i, err := strconv.ParseInt(string(str), 10, 64); err != nil {
+	if totalDigits == 0 {
 		return 0, false
-	} else {
-		return int(i), true
 	}
+	return n, true
 }
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -139,109 +139,110 @@ func TestIsANumber(t *testing.T) {
 
 func TestIsADigit(t *testing.T) {
 	expected := []struct {
-		b     string
-		ok    bool
-		input []bool
+		val    int
+		digits int
+		ok     bool
+		input  []bool
 	}{
-		{"", false, []bool{
+		{0, 0, false, []bool{
 			false,
 			false, false,
 			false,
 			false, false,
 			true,
 		}},
-		{"", true, []bool{
+		{0, 0, true, []bool{
 			false,
 			false, false,
 			false,
 			false, false,
 			false,
 		}},
-		{"1", true, []bool{
+		{1, 1, true, []bool{
 			false,
 			true, false,
 			false,
 			true, false,
 			false,
 		}},
-		{"1", true, []bool{
+		{1, 1, true, []bool{
 			false,
 			false, true,
 			false,
 			false, true,
 			false,
 		}},
-		{"2", true, []bool{
+		{2, 1, true, []bool{
 			true,
 			false, true,
 			true,
 			true, false,
 			true,
 		}},
-		{"3", true, []bool{
+		{3, 1, true, []bool{
 			true,
 			false, true,
 			true,
 			false, true,
 			true,
 		}},
-		{"4", true, []bool{
+		{4, 1, true, []bool{
 			false,
 			true, true,
 			true,
 			false, true,
 			false,
 		}},
-		{"5", true, []bool{
+		{5, 1, true, []bool{
 			true,
 			true, false,
 			true,
 			false, true,
 			true,
 		}},
-		{"6", true, []bool{
+		{6, 1, true, []bool{
 			true,
 			true, false,
 			true,
 			true, true,
 			true,
 		}},
-		{"7", true, []bool{
+		{7, 1, true, []bool{
 			true,
 			false, true,
 			false,
 			false, true,
 			false,
 		}},
-		{"8", true, []bool{
+		{8, 1, true, []bool{
 			true,
 			true, true,
 			true,
 			true, true,
 			true,
 		}},
-		{"9", true, []bool{
+		{9, 1, true, []bool{
 			true,
 			true, true,
 			true,
 			false, true,
 			true,
 		}},
-		{"9", true, []bool{
+		{9, 1, true, []bool{
 			true,
 			true, true,
 			true,
 			false, true,
 			false,
 		}},
-		{"0", true, []bool{
+		{0, 1, true, []bool{
 			true,
 			true, true,
 			false,
 			true, true,
 			true,
 		}},
-		{"11", true, []bool{
+		{11, 2, true, []bool{
 			false,
 			true, true,
 			false,
@@ -250,8 +251,8 @@ func TestIsADigit(t *testing.T) {
 		}},
 	}
 	for i, each := range expected {
-		if b, ok := isADigit(each.input); string(b) != each.b || ok != each.ok {
-			log.Printf("Failed on #%d (expected %s) got (%s %v)", i, each.b, b, ok)
+		if val, digits, ok := isADigit(each.input); val != each.val || digits != each.digits || ok != each.ok {
+			log.Printf("Failed on #%d (expected %d, %d) got (%d, %d, %v)", i, each.val, each.digits, val, digits, ok)
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
Refactor isANumber to use integer arithmetic

Refactor `isANumber` and `isADigit` to use integer arithmetic instead of string allocation and parsing.
- Modified `isADigit` to return `(int, int, bool)` (value, digit count, success).
- Updated `isANumber` to construct the integer value using arithmetic.
- Updated `TestIsADigit` in `main_test.go` to match the new signature.
- Removed unused `strconv` import.

This improves performance by avoiding string allocations and parsing overhead.

---
*PR created automatically by Jules for task [14878196017562891893](https://jules.google.com/task/14878196017562891893) started by @arran4*