### PR TITLE
test: add unit test for drawMatch function

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"image"
+	"image/color"
 	"log"
 	"testing"
 )
@@ -255,4 +257,66 @@ func TestIsADigit(t *testing.T) {
 			t.Fail()
 		}
 	}
+}
+
+func TestDrawMatch(t *testing.T) {
+	// Setup
+	r := image.Rect(0, 0, 200, 200)
+	img := image.NewRGBA(r)
+
+	// Helper to check pixel color
+	checkPixel := func(x, y int, expected color.Color, name string) {
+		got := img.At(x, y)
+		r1, g1, b1, a1 := got.RGBA()
+		r2, g2, b2, a2 := expected.RGBA()
+		if r1 != r2 || g1 != g2 || b1 != b2 || a1 != a2 {
+			t.Errorf("%s: pixel at (%d, %d) expected %v, got %v", name, x, y, expected, got)
+		}
+	}
+
+	// 1. Horizontal Match (leftRight = true)
+	// drawMatch(img, 10, 10, true)
+	// Head: (10,10) to (19,19)
+	// Stick: (20,10) to (109,19)
+	err := drawMatch(img, 10, 10, true)
+	if err != nil {
+		t.Fatalf("drawMatch failed: %v", err)
+	}
+
+	// Check Head
+	checkPixel(10, 10, matchHeadColour, "Horizontal Head TopLeft")
+	checkPixel(19, 19, matchHeadColour, "Horizontal Head BottomRight")
+
+	// Check Stick
+	checkPixel(20, 10, matchColour, "Horizontal Stick Start")
+	checkPixel(109, 19, matchColour, "Horizontal Stick End")
+
+	// Check surroundings (cleanliness)
+	checkPixel(9, 10, color.Transparent, "Horizontal Left Clean") // Left of head
+	checkPixel(10, 9, color.Transparent, "Horizontal Top Clean") // Above head
+	checkPixel(110, 10, color.Transparent, "Horizontal Right Clean") // Right of stick
+	checkPixel(10, 20, color.Transparent, "Horizontal Bottom Clean") // Below head
+
+	// 2. Vertical Match (leftRight = false)
+	// drawMatch(img, 10, 50, false)
+	// Head: (10,50) to (19,59)
+	// Stick: (10,60) to (19,149)
+	err = drawMatch(img, 10, 50, false)
+	if err != nil {
+		t.Fatalf("drawMatch failed: %v", err)
+	}
+
+	// Check Head
+	checkPixel(10, 50, matchHeadColour, "Vertical Head TopLeft")
+	checkPixel(19, 59, matchHeadColour, "Vertical Head BottomRight")
+
+	// Check Stick
+	checkPixel(10, 60, matchColour, "Vertical Stick Start")
+	checkPixel(19, 149, matchColour, "Vertical Stick End")
+
+	// Check surroundings
+	checkPixel(9, 50, color.Transparent, "Vertical Left Clean")
+	checkPixel(10, 49, color.Transparent, "Vertical Top Clean")
+	checkPixel(10, 150, color.Transparent, "Vertical Bottom Clean")
+	checkPixel(20, 50, color.Transparent, "Vertical Right Clean")
 }


### PR DESCRIPTION
Added a unit test for `drawMatch` in `main_test.go`.
- Tested horizontal (`leftRight=true`) and vertical (`leftRight=false`) match drawing.
- Verified pixel colors for the match head and stick.
- Verified that pixels outside the match area remain transparent.
- Used `image.NewRGBA` for in-memory image testing.

---
*PR created automatically by Jules for task [9634494930148224056](https://jules.google.com/task/9634494930148224056) started by @arran4*