### PR TITLE
Remerge PR #15: Add segment constants and fix main_test.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,6 +28,15 @@ const (
 	marginHeight    = matchWidth
 	marginWidth     = matchWidth
 	spacing         = matchWidth
+
+	segTop         = 0
+	segTopLeft     = 1
+	segTopRight    = 2
+	segMiddle      = 3
+	segBottomLeft  = 4
+	segBottomRight = 5
+	segBottom      = 6
+	segCount       = 7
 )
 
 var (
@@ -79,30 +88,30 @@ func drawPic(input []bool, img draw.Image) error {
 		if !each {
 			continue
 		}
-		pos := i % 7
+		pos := i % segCount
 		x := marginWidth
-		x += (i / 7) * (digitWidth + spacing)
+		x += (i / segCount) * (digitWidth + spacing)
 		switch pos {
-		case 1, 4:
-		case 2, 5:
+		case segTopLeft, segBottomLeft:
+		case segTopRight, segBottomRight:
 			x += matchLength
 			fallthrough
-		case 0, 3, 6:
+		case segTop, segMiddle, segBottom:
 			x += matchWidth
 		}
 		y := marginHeight
-		left := pos == 0 || pos == 3 || pos == 6
+		left := pos == segTop || pos == segMiddle || pos == segBottom
 		switch pos {
-		case 6:
+		case segBottom:
 			y += matchLength
 			fallthrough
-		case 4, 5:
+		case segBottomLeft, segBottomRight:
 			y += matchWidth
 			fallthrough
-		case 3:
+		case segMiddle:
 			y += matchLength
 			fallthrough
-		case 1, 2:
+		case segTopLeft, segTopRight:
 			y += matchWidth
 		}
 		err := drawMatch(img, x, y, left)
@@ -152,8 +161,8 @@ func isADigit(a []bool) ([]byte, bool) {
 
 func isANumber(a []bool) (int, bool) {
 	str := []byte{}
-	for i := 0; i < len(a); i += 7 {
-		if b, ok := isADigit(a[i : i+7]); !ok {
+	for i := 0; i < len(a); i += segCount {
+		if b, ok := isADigit(a[i : i+segCount]); !ok {
 			return 0, false
 		} else {
 			str = append(str, b...)
@@ -221,7 +230,7 @@ func main() {
 	fontSize, _ := font.BoundString(inconsolata.Regular8x16, "01234\n56789")
 
 	digitBase := digitHeight*1 + marginHeight*2
-	r := image.Rect(0, 0, digitWidth*len(initial)/7+spacing*3+marginWidth*2, digitBase+fontSize.Max.Y.Ceil())
+	r := image.Rect(0, 0, digitWidth*len(initial)/segCount+spacing*3+marginWidth*2, digitBase+fontSize.Max.Y.Ceil())
 	p := color.Palette{
 		backgroundColour,
 		matchColour,

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"reflect"
 	"testing"
 )
 


### PR DESCRIPTION
This PR remerges the changes from PR #15 into the current codebase.

The original PR introduced named constants for the 7-segment display segments to replace magic numbers.

Changes applied:
- Added `segTop`, `segTopLeft`, `segTopRight`, `segMiddle`, `segBottomLeft`, `segBottomRight`, `segBottom`, and `segCount` constants to `main.go`.
- Updated `drawPic` to use these constants for segment positioning and drawing logic.
- Updated `isANumber` and `main` to use `segCount` instead of hardcoded `7`.
- `isADigit` was NOT updated to use the switch statement from the PR because the current implementation uses a lookup table optimization which is superior and structurally different.

Additionally:
- Fixed a compilation error in `main_test.go` where `reflect` was used but not imported. Verified tests pass.

---
*PR created automatically by Jules for task [2801127445007174619](https://jules.google.com/task/2801127445007174619) started by @arran4*