### PR TITLE
Upgrade golang.org/x/image to v0.39.0 for CVE-2026-33809

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.25.3
 
 require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	golang.org/x/image v0.38.0
+	golang.org/x/image v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
-golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
-golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
+golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=


### PR DESCRIPTION
Upgraded `golang.org/x/image` dependency from `v0.38.0` to `v0.39.0` to mitigate the security vulnerability CVE-2026-33809. Ran `go mod tidy` to update both `go.mod` and `go.sum` correctly.

---
*PR created automatically by Jules for task [4987441112728528050](https://jules.google.com/task/4987441112728528050) started by @arran4*