### PR TITLE
ci: Fix golangci-lint action compliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -260,7 +260,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - name: Test
         run: go test ./... -v
@@ -274,7 +274,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - run: go vet ./...
 
@@ -287,7 +287,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: true
       - name: check for go vulnerabilities
         uses: golang/govulncheck-action@v1
@@ -305,7 +305,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: Run go fmt
         run: go fmt ./...
       - name: Create PR if go fmt changed files
@@ -334,7 +334,7 @@ jobs:
       - name: Setup Go (if needed)
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - name: Run autofix formatters
         shell: bash
@@ -404,7 +404,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: go.mod
       - name: Tag commit for release (workflow_dispatch)
         if: ${{ github.event_name == 'workflow_dispatch' && startsWith(inputs.mode, 'release-') }}
         run: git tag ${{ needs.prepare-release-tag.outputs.release_tag }}


### PR DESCRIPTION
Fixes GitHub Actions workflows by ensuring that the `setup-go` action uses the `go.mod` file for version synchronization instead of a hardcoded version. Complies with explicit LLM constraint guidelines for resolving `golangci-lint` errors without downgrading local project definitions.

---
*PR created automatically by Jules for task [18347739419150928460](https://jules.google.com/task/18347739419150928460) started by @arran4*