### PR TITLE
Fix cache extraction error in Go vulnerability check workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,10 +285,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
       - name: check for go vulnerabilities
         uses: golang/govulncheck-action@v1
         with:


### PR DESCRIPTION
This PR removes the redundant `actions/setup-go` step from the `go-vuln` job in `.github/workflows/ci.yml`.

The `golang/govulncheck-action` action automatically manages its own Go setup and caching. Setting up Go with caching immediately before it caused cache extraction conflicts, as the vulnerability check action attempted to overwrite read-only cache files created by the first setup step, resulting in `tar` "File exists" errors.

---
*PR created automatically by Jules for task [10405030060081909192](https://jules.google.com/task/10405030060081909192) started by @arran4*