### PR TITLE
ci: fix goreleaser generating gif step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_CURRENT_TAG: ${{ needs.prepare-release-tag.outputs.release_tag }}
       - name: Generate gif
-        run: go run . -out out.gif
+        run: go run ./cmd/matchStickProblem run -out out.gif
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
Update ci.yml to point go run at cmd/matchStickProblem since the main package is no longer in the root folder, and add the required `run` subcommand.

---
*PR created automatically by Jules for task [14392558488793203162](https://jules.google.com/task/14392558488793203162) started by @arran4*